### PR TITLE
fix: replace bitnami/zookeeper with official zookeeper:3.9

### DIFF
--- a/docker_exp/docker-compose.yml
+++ b/docker_exp/docker-compose.yml
@@ -19,7 +19,7 @@ services:
   zookeeper:  # the configuration manager
     hostname: ZOOKEEPER
     container_name: zookeeper
-    image: 'bitnami/zookeeper'
+    image: zookeeper:3.9
     ports:
       - 2181:2181
     environment:


### PR DESCRIPTION
Hi sir,

I noticed that the image 'bitnami/zookeeper' in docker-compose.yml is no longer available or like when running with that line it caused an error when running docker-compose up -d.So like if someone faces this issue in his/her system with that line he/she can write this in line#22

Replacing it with:

image: zookeeper:3.9

worked successfully.
Thank you!